### PR TITLE
python:alpine moved to 3.13

### DIFF
--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -28,7 +28,7 @@ FROM --platform=$TARGETPLATFORM python:alpine AS run
 RUN adduser -S fritz -G root
 USER fritz
 
-COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --chown=fritz:root python /home/fritz/python
 
 EXPOSE 8080

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -28,7 +28,7 @@ FROM --platform=$TARGETPLATFORM python:alpine AS run
 RUN adduser -S fritz -G root
 USER fritz
 
-COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --chown=fritz:root python /home/fritz/python
 COPY --chown=fritz:root static /home/fritz/static
 


### PR DESCRIPTION
As I was executing the `plano build` commands to make the `hello-world` images effective on our quay.io/skupper, the build failed because the most recent python:alpine has Python 3.13, but our Containerfile expected 3.12.