### PR TITLE
MULTIARCH-5587: Enabling power arch image builds for v2

### DIFF
--- a/.github/workflows/build-multiarch-backend.yml
+++ b/.github/workflows/build-multiarch-backend.yml
@@ -1,5 +1,13 @@
 name: Build and Push Multi-Arch Image
-on: [push]
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/build-multiarch-backend.yml'
+      
+  workflow_dispatch:
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-multiarch-backend.yml
+++ b/.github/workflows/build-multiarch-backend.yml
@@ -1,0 +1,23 @@
+name: Build and Push Multi-Arch Image
+on: [push]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Quay
+        run: |
+          echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u "${{ secrets.QUAY_USER }}" --password-stdin
+      
+      - name: Build and Push Multi-Arch Image
+        run: |
+          ./plano --file backend/.plano.py build,push 

--- a/.github/workflows/build-multiarch-frontend.yml
+++ b/.github/workflows/build-multiarch-frontend.yml
@@ -1,0 +1,23 @@
+name: Build and Push Multi-Arch Image
+on: [push]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Quay
+        run: |
+          echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u "${{ secrets.QUAY_USER }}" --password-stdin
+      
+      - name: Build and Push Multi-Arch Image
+        run: |
+          ./plano --file frontend/.plano.py update-gesso,build,push

--- a/.github/workflows/build-multiarch-frontend.yml
+++ b/.github/workflows/build-multiarch-frontend.yml
@@ -1,5 +1,13 @@
 name: Build and Push Multi-Arch Image
-on: [push]
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/build-multiarch-frontend.yml'
+      
+  workflow_dispatch:
 
 jobs:
   build-and-push:

--- a/backend/.plano.py
+++ b/backend/.plano.py
@@ -25,7 +25,9 @@ image_tag = "quay.io/skupper/hello-world-backend"
 def build(no_cache=False):
     no_cache_arg = "--no-cache" if no_cache else ""
 
-    run(f"podman build {no_cache_arg} --format docker -t {image_tag} .")
+    run(f"podman manifest rm {image_tag}", check=False)
+    run(f"podman rmi {image_tag}", check=False)
+    run(f"podman build {no_cache_arg} --format docker --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le --file backend/Containerfile --manifest {image_tag} ./backend")
 
 @command
 def run_():
@@ -38,4 +40,4 @@ def debug():
 @command
 def push():
     run("podman login quay.io")
-    run(f"podman push {image_tag}")
+    run(f"podman manifest push {image_tag}")

--- a/backend/Containerfile
+++ b/backend/Containerfile
@@ -26,7 +26,7 @@ FROM python:alpine AS run
 RUN adduser -S fritz -G root
 USER fritz
 
-COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --chown=fritz:root python /home/fritz/python
 
 EXPOSE 8080

--- a/frontend/.plano.py
+++ b/frontend/.plano.py
@@ -26,7 +26,9 @@ image_tag = "quay.io/skupper/hello-world-frontend"
 def build(no_cache=False):
     no_cache_arg = "--no-cache" if no_cache else ""
 
-    run(f"podman build {no_cache_arg} --format docker -t {image_tag} .")
+    run(f"podman manifest rm {image_tag}", check=False)
+    run(f"podman rmi {image_tag}", check=False)
+    run(f"podman build {no_cache_arg} --format docker --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le --file frontend/Containerfile --manifest {image_tag} ./frontend")
 
 @command
 def run_():
@@ -57,7 +59,7 @@ def debug():
 @command
 def push():
     run("podman login quay.io")
-    run(f"podman push {image_tag}")
+    run(f"podman manifest push {image_tag}")
 
 @command
 def update_gesso():

--- a/frontend/Containerfile
+++ b/frontend/Containerfile
@@ -26,7 +26,7 @@ FROM python:alpine AS run
 RUN adduser -S fritz -G root
 USER fritz
 
-COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --chown=fritz:root python /home/fritz/python
 COPY --chown=fritz:root static /home/fritz/static
 


### PR DESCRIPTION
This PR contains changes as follows:

> * Enabling power arch image builds for v2
> * Enabling plano tool for all image builds
> * Added new github action workflow files for frontend and backend
> * updated python version in Containerfiles as tag alpine uses updated python v3.14


I'm verifying Skupper on Power for [MULTIARCH-5587](https://issues.redhat.com/browse/MULTIARCH-5587)

Details of successful validations of workflow files with custom images built - 

> 1. main
>     - [Main Workflow](https://github.com/KaushikOP/skupper-example-hello-world/actions/runs/20464168578)
> 
>
> 2. backend
>     - [Backend Workflow](https://github.com/KaushikOP/skupper-example-hello-world/actions/runs/20464168681)
>     - [Generated Backend Images](https://quay.io/repository/ktalathi/skupper/hello-world-backend?tab=tags)
>     
>
> 3. frontend
>     - [Frontend Workflow](https://github.com/KaushikOP/skupper-example-hello-world/actions/runs/20464168582)
>     - [Generated Frontend Images](https://quay.io/repository/ktalathi/skupper/hello-world-frontend?tab=tags)

CC: @prb112, @mjturek & @hash-d